### PR TITLE
fix: Correct font asset path for case sensitivity

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -273,7 +273,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,5 +26,4 @@ flutter:
   fonts:
     - family: ComicShanns
       fonts:
-        - asset: lib/fonts/comic-Shanns-2.ttf
-
+        - asset: lib/fonts/comic-shanns-2.ttf


### PR DESCRIPTION
Fixes: #1 

The application failed to compile on Linux and Web platforms with an "Error: unable to locate asset entry in pubspec.yaml: 'lib/fonts/comic-Shanns-2.ttf'" diagnostic.

Upon investigation, it was discovered that the `pubspec.yaml` file specified the font asset path as `lib/fonts/comic-Shanns-2.ttf` (with a capital 'S' in Shanns). However, the actual filename was `lib/fonts/comic-shanns-2.ttf` (with a lowercase 's').

Linux filesystems are case-sensitive, leading to a mismatch between the declared asset path and the actual file location, thereby causing the build failure.

This commit corrects the `pubspec.yaml` entry to precisely match the case of the font file.